### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you've designed a collection of Claude Code plugins for various AI development tasks, aiming to streamline the process of building applications. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [CRITICAL] Skill auto-approves unrestricted shell
   File: plugins/a2a-protocol/skills/a2a-executor-patterns/SKILL.md
   What it means: This skill's allowed-tools pre-approves unrestricted shell — a bare `Bash` grant or `Bash(*)`.

2. [CRITICAL] Skill auto-approves unrestricted shell
   File: plugins/a2a-protocol/skills/a2a-mcp-integration/SKILL.md
   What it means: This skill's allowed-tools pre-approves unrestricted shell — a bare `Bash` grant or `Bash(*)`.

3. [CRITICAL] Bundled skill script reads credentials or secrets
   File: plugins/a2a-protocol/skills/a2a-mcp-integration/SKILL.md
   What it means: A script bundled with this skill reads credentials or secrets (gh auth, $AWS_*, ~/.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)